### PR TITLE
JWT issue fixed while validating Rememberme Cookie: Issue #12

### DIFF
--- a/src/main/java/com/aaonews/utils/SessionUtil.java
+++ b/src/main/java/com/aaonews/utils/SessionUtil.java
@@ -82,12 +82,14 @@ public class SessionUtil {
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if (REMEMBER_ME_COOKIE.equals(cookie.getName())) {
-                    String value = cookie.getValue();
-                    String[] parts = value.split(":");
-                    if (parts.length == 2) {
+                    String token = cookie.getValue();
+                    String userIdStr = JWTUtil.validateToken(token);
+                    if (userIdStr != null) {
                         try {
-                            return Integer.parseInt(parts[0]);
+                            return Integer.parseInt(userIdStr);
                         } catch (NumberFormatException e) {
+                            // Log the error
+                            System.err.println("Failed to parse user ID from token: " + e.getMessage());
                             return -1;
                         }
                     }


### PR DESCRIPTION
Fixed the issue where Jwt token was not validated while parsing cookie from the HTTP request. Fixed SessionUtil class ->getUserIdFromRememberMeCookie(HttpServletRequest request) method to properly parse the cookie and get user id from the token.